### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server implementation that integrates Claude with Salesforce, enabling natural language interactions with your Salesforce data and metadata. This server allows Claude to query, modify, and manage your Salesforce objects and records using everyday language.
 
+<a href="https://glama.ai/mcp/servers/n1rsv1aiee">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/n1rsv1aiee/badge" alt="Salesforce Server MCP server" />
+</a>
+
 ## Features
 
 * **Object and Field Management**: Create and modify custom objects and fields using natural language


### PR DESCRIPTION
This PR adds a badge for the [Salesforce MCP Server](https://glama.ai/mcp/servers/n1rsv1aiee) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/n1rsv1aiee">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/n1rsv1aiee/badge" alt="Salesforce Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.